### PR TITLE
fix: export correct speed to PDF

### DIFF
--- a/scripts/dsa5-char2pdf.js
+++ b/scripts/dsa5-char2pdf.js
@@ -573,6 +573,9 @@ async function fillForm(dsa_actor_id) {
     /** general */
 
     form.getTextField('LE_Max_2').setText(entity.system.status.wounds.max + '');
+    // Don't use the max attribute of speed. It is allways 0.
+    const speed = entity.system.status.speed;
+    form.getTextField('GS_Max_1').setText(String(speed.initial + speed.modifier + speed.gearmodifier));
     form.getTextField('GS_Max_1').setText(entity.system.status.speed.max + '');
     form.getTextField('AW_Max_2').setText(entity.system.status.dodge.max + '');
     form.getTextField('INI_Max_1').setText((entity.system.characteristics.mu.value + entity.system.characteristics.ge.value) / 2 + '');

--- a/scripts/dsa5-char2pdf.js
+++ b/scripts/dsa5-char2pdf.js
@@ -576,7 +576,6 @@ async function fillForm(dsa_actor_id) {
     // Don't use the max attribute of speed. It is allways 0.
     const speed = entity.system.status.speed;
     form.getTextField('GS_Max_1').setText(String(speed.initial + speed.modifier + speed.gearmodifier));
-    form.getTextField('GS_Max_1').setText(entity.system.status.speed.max + '');
     form.getTextField('AW_Max_2').setText(entity.system.status.dodge.max + '');
     form.getTextField('INI_Max_1').setText((entity.system.characteristics.mu.value + entity.system.characteristics.ge.value) / 2 + '');
     form.getTextField('AW_Max_2').setText(entity.system.status.dodge.max + '');


### PR DESCRIPTION
The value for speed is allways exported as zero because of the used attribute is allways zero in Foundry. I changed the code to calculate the actual speed on the fly.